### PR TITLE
Change debian dependencies for ubuntu 20.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Homepage: http://www.bloonix.de/
 
 Package: bloonix-core
 Architecture: all
-Depends: ${perl:Depends}, ca-certificates, openssl, libhttp-tiny-perl (>= 0.022), libio-compress-perl, libio-socket-inet6-perl, libio-socket-ssl-perl (>= 1.77), libjson-perl, libjson-xs-perl, liblog-handler-perl (>= 0.84), libnet-snmp-perl, libnetaddr-ip-perl, libparams-validate-perl, libsocket6-perl, libtime-modules-perl, libnet-dns-perl
+Depends: ${perl:Depends}, ca-certificates, openssl, libhttp-tiny-perl (>= 0.022), libio-compress-perl, libio-socket-inet6-perl, libio-socket-ssl-perl (>= 1.77), libjson-perl, libjson-xs-perl, liblog-handler-perl (>= 0.84), libnet-snmp-perl, libnetaddr-ip-perl, libparams-validate-perl, libsocket6-perl, libtime-parsedate-perl, libnet-dns-perl
 Description: Bloonix core modules
  Core modules for the Bloonix application.


### PR DESCRIPTION
I just changed `libtime-modules-perl` to `libtime-parsedate-perl` in order to be able to install on ubuntu 20.04.

I don't know how you build and update the repositories/https://bloonix-monitoring.org/en/docs/installation/repositories.html but I worked out only changing this dep and running ar rcs again only in this repository